### PR TITLE
Annoying conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
     * behave respectfully towards other people — they’re real humans, just like you
     * be considerate of people’s time and attention
     * contribute positively and constructively to discussions
-        * We want a high signal-to-noise ratio, so if a discussion is devolving into snark and name-calling, either let it die or raise the tone. Lead by example.
-        * On the other hand, if someone's acted out of line, it's the community's responsibility to make that crystal clear to them. The standard you walk past is the standard you accept.
+    * We want a high signal-to-noise ratio and expect you to: 
+       * Lead by example - If a discussion is devolving into snark and name-calling, either let it die or raise the tone.
+       * Keep standards high - If someone acts out of line, make that crystal clear to them.
 * all LRUG participants are accountable for their own behaviour
 * please report any inappropriate or harmful behaviour to:
     * [Aanand](http://aanandprasad.com/) ([@aanand](http://twitter.com/aanand), [aanand.prasad@gmail.com](mailto:aanand.prasad@gmail.com))


### PR DESCRIPTION
I like the sentiment of:

> - contribute positively and constructively to discussions
>   - we want a high signal-to-noise ratio
>   - joining an annoying conversation will cause it to escalate, but ignoring it will kill it off

but the "ignoring it" bit seems bad.  Ignoring the evvnt email would have been terrible.  Ignoring the "please talk about this silly feminist stuff elsewhere" email also would have been terrible.

Yes, I want to suggest that piling on is bad.  Yes, I want signal-to-noise.  I also want people to feel like they should speak out when stuff is wrong.  Obviously [lrug.org/team](http://lrug.org/team) will chip in, but it would be good if the rest of the community did so too and it felt less like parents disciplining unruly children.
