### PR TITLE
add links to educational resources on harassment/exclusion

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ On the mailing list, we want to maintain a high signal-to-noise ratio, so please
 
 LRUG is anti-harassment in all forms, including invasions of personal space and exclusionary jokes/comments. If you make anyone feel uncomfortable or unwelcome, you will be asked to leave.
 
-If you are not sure what we mean by harassment or exclusion, there are [several](https://github.com/nickelcityruby/code-of-conduct/blob/master/code_of_conduct.md#the-longer-version) [good](http://theangryblackwoman.com/2009/10/01/the-dos-and-donts-of-being-a-good-ally/) [resources](http://www.shakesville.com/2010/01/feminism-101.html) [online](http://www.shakesville.com/2010/01/feminism-101.html) which we encourage you read. The main thing to remember though, is that if someone feels harassed or excluded by your words or actions, then those words or actions constitute harassment or exclusion. Your intent is *not* a factor.
+If you are not sure what we mean by harassment or exclusion, there are [several](https://us.pycon.org/2012/codeofconduct/) [good](http://theangryblackwoman.com/2009/10/01/the-dos-and-donts-of-being-a-good-ally/) [resources](http://www.shakesville.com/2010/01/feminism-101.html) [online](http://www.shakesville.com/2010/01/feminism-101.html) which we encourage you read. The main thing to remember though, is that if someone feels harassed or excluded by your words or actions, then those words or actions constitute harassment or exclusion. Your intent is *not* a factor.
 
 All LRUG participants are accountable for their own behaviour. If you’ve behaved badly elsewhere, that may count against you here, because of the effect it has on other attendees.
 


### PR DESCRIPTION
The "If you make anyone feel uncomfortable or unwelcome, you will be asked to leave" sentence is a very clear and succinct explanation of what constitutes harassment, and what the consequences are;  In general, I think the brevity / generality of the anti-harassment statement (as opposed to the rather more verbose style of enumerating a long but non-exhaustive list of forms harassment can take) is a good thing, as it's intrinsically open-ended.

I feel there's a trade-off here though: making the anti-harassment statement as general and open-ended allows us to react to unforeseen forms of harassment more easily than if we had an explicit list of behaviours constituting
harassment (and reduces the potential for language-lawyering).

However, a more explicit statement of what actions and behaviours constitute harassment would be advantageous from a pro-active point of view, as it'd better allow LRUG attendees to educate themselves and
monitor their own behaviour before an incident happens. 

With that in mind, I've added a paragraph with links to some useful anti-harassment 101s, as well as explicit statement that good-faith intentions are not a defence. I think this should help educate people and allow us to monitor our own behaviour, without over-burdening the anti-harassment policy with specifics (and hence diluting it, as described above).

(Thanks to @camilleldn who collaborated on this)

Cheers!

Tim
