### PR TITLE
Code of conduct: Explicit list vs. catch all wording

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,9 +40,11 @@ On the mailing list, we want to maintain a high signal-to-noise ratio and while 
 
 ### Incident Handling
 
-LRUG is anti-harassment in all forms, and we're dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of our members in any form, including invasions of personal space and exclusionary jokes/comments. Sexual language and imagery is not appropriate at any LRUG venue; not at the talks, not at the pub after the talks, or any other LRUG social meeting; not on Twitter or on any other online media. Please note that this list is non-exhaustive; if you make anyone feel uncomfortable or unwelcome, you will be asked to leave.
+We want everyone to feel welcome at LRUG, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. Accordingly, we will not tolerate harassment of our members in any form; not at the talks, not at the pub after the talks, or any other LRUG social meeting; not on Twitter or on any other online media.
 
-If you are not sure what we mean by harassment or exclusion, there are [several](https://us.pycon.org/2012/codeofconduct/) [good](http://theangryblackwoman.com/2009/10/01/the-dos-and-donts-of-being-a-good-ally/) [resources online](http://www.shakesville.com/2010/01/feminism-101.html) which we encourage you read. The main thing to remember though, is that if someone feels harassed or excluded by your words or actions, then those words or actions constitute harassment or exclusion. Your intent is *not* a factor.
+Harassment includes invasions of personal space, exclusionary jokes/comments, and sexual language and imagery in talks, but this list is non-exhaustive: if you make anyone feel uncomfortable or unwelcome, you will be asked to leave.
+
+If you’re still in need of clarification, there are [several](https://us.pycon.org/2012/codeofconduct/) [good](http://theangryblackwoman.com/2009/10/01/the-dos-and-donts-of-being-a-good-ally/) [resources online](http://www.shakesville.com/2010/01/feminism-101.html) which we encourage you read. The main thing to remember though, is that if someone feels harassed or excluded by your words or actions, then those words or actions constitute harassment or exclusion. Your intent is *not* a factor.
 
 All LRUG participants are accountable for their own behaviour. If you’ve behaved badly elsewhere, that may count against you here, because of the effect it has on other attendees.
 


### PR DESCRIPTION
As seen in #8 we're already a bit unsure that the code of conduct isn't clear enough about what is / isn't acceptable.  We've had some feedback along the same lines, so it's clear we're not 100% there yet.
### Feedback

@ashedryden:

> I personally prefer a more concrete code of conduct (I particularly like JSConf's), 
> because it more obviously lays the ground rules for everyone. This helps avoid any 
> arguments about what the code of conduct does and doesn't cover, as letting people 
> know what kind of behavior isn't acceptable so they can more easily report.

@h-lame replied:

> We consciously chose a less concrete set of rules so that we wouldn’t get into 
> language lawyer discussions with any transgressors (“you can’t ban me, the code 
> says no X & Y, I did Z”) or with commenters on the code itself (“oh, I think X isn’t a 
> problem”).  Maybe we're wrong though?

@ashedryden replied:

> I can certainly understand this, but you'll probably get people arguing with you 
> regardless. "It was just a joke!" "That isn't harassment!" "I didn't mean to hurt 
> people's feelings" etc, so I would be prepared for that regardless. 

@aanand said:

> I agree that, in striving for concision, we ended up with something perhaps a bit 
> vague. Two other folks had similar feedback and added a paragraph with some links 
> to more concrete resources, including the PyCon COC (see #12).
> 
> I think it's an improvement, at least (and I'm happy that we've got a link to 
> Shakesville in there now, too). What do you reckon?

and @ashedryden replied:

> I personally prefer having that information inline versus having to go offsite for it. Not 
> everyone will click those links and stating it explicitly from your organization versus 
> someone else's removes any gray area, I think?

In a separate thread @timcowlishaw said:

> The "If you make anyone feel uncomfortable or unwelcome, you will be
> asked to leave" sentence is a very clear and succinct explanation of
> what constitutes harassment, and what the consequences are;  In
> general, I think the brevity / generality of the anti-harassment
> statement (as opposed to the rather more verbose style of enumerating
> a long but non-exhaustive list of forms harassment can take) is a good
> thing, as it's intrinsically open-ended. I feel there's a trade-off
> here though: making the anti-harassment statement as general and
> open-ended allows us to react to unforseen forms of harassment more
> easily than if we had an explicit list of behaviours constituting
> harassment (and reduces the potential for language-lawyering).
> However, a more explicit statement of what actions and behaviours
> constitute harassment would be advantageous from a pro-active point of
> view, as it'd better allow LRUG attendees to educate themselves and
> monitor their own behaviour before an incident happens.

And this then turned into the aforementioned #12 to add the educational stuff.
