### PR TITLE
Add an 'About this document' section.

### DIFF
--- a/index.md
+++ b/index.md
@@ -61,8 +61,8 @@ to a member of the [volunteer team](#volunteer-team).
 If you'd like to join the volunteer team please contact
 [Murray Steele](http://h-lame.com/)
 ([@hlame](http://twitter.com/hlame),
-[murray.steele@lrug.org](mailto:murray.steele@lrug.org)) in the first
-instance.
+[murray.steele@lrug.org](mailto:murray.steele@lrug.org)) or one of the
+other [volunteers](#volunteer-team).
 
 ## Meetings
 


### PR DESCRIPTION
This PR addresses https://github.com/lrug/lrug.github.io/issues/21, and comes with my apologies for taking so long to get it together. 

It adds a short paragraph on the origin of the document, and then
outlines how subsequent, and future changes to it can be made. I've
hand-waved a bit on how proposed changes are incorporated into the
document, but based it on the closed issues in the github repo, that is,
the discussion around any changes is open and in the public, and when
consensus is reached the changes are merged in.

On the issue of volunteering, to address primarily how named people in
the document are 'appointed', I've added a short paragraph on
volunteering, which encourages the reader to contact @hlame in the first
instance.
