### PR TITLE
Add new organising section

### DIFF
--- a/organising/index.md
+++ b/organising/index.md
@@ -1,0 +1,265 @@
+---
+layout: default
+title: organising LRUG
+---
+
+# Organising LRUG
+
+LRUG doesn't happen spontaneously every month it takes care and attention to detail to make sure it runs smoothly.  These pages are here to help you if it's your turn to organise one of our meetings.
+
+ * [Being responsible for a meeting](#being-responsible-for-a-meeting)
+   * [Arranging speakers](#arranging-speakers)
+   * [Dealing with sponsors](#dealing-with-sponsors)
+   * [Hosting](#hosting)
+   * [Comms](#comms)
+ * [Moderating the mailing list](#moderating-the-mailing-list)
+ * [Dealing with incoming mail](#dealing-with-incoming-mail)
+
+## Being responsible for a meeting
+
+We use [Harmonia](https://harmonia.io/teams/ukieh7/tasks) to pick someone to act as supervisor for each meeting.  This is assigned about 2 months in advance of a meeting.  For example if you are picked to supervise the August meeting you will be chosen by Harmonia in early June.  Assigning it early gives us the opportunity to reassign if the chosen person will be busy, and gives them plenty of time to set things going.  The 2 month window is also to provide time for us to arrange the meeting details with enough time to give speakers, sponsors, and our hosts plenty of lead time on the meeting.
+
+As supervisor it is not your responsibility to do everthing for a given meeting, but to make sure that someone is assigned to each task, and that the rest of the organisers know who it is.  In many cases the supervisor *will* choose to do all the work for their meeting, but they don't have to.  When you are chosen to supervise you should lean on the other organisers are much as possible for help, advice, and people to delegate to.
+
+The supervisor should pick someone to:
+
+* [Arrange the speakers](#arranging-speakers)
+* [Deal with sponsors](#dealing-with-sponsors)
+* [Host the meeting](#hosting)
+* [Tell people about the meeting](#comms)
+* [Deal with incoming email](#dealing-with-incoming-email)
+
+### Arranging speakers
+
+#### Timing
+
+Our meeting lasts for 90 minutes; from 6:30pm until 8pm.  We leave at least 10 minutes to account for our admin announcements and laptop switch over time which means we have 80 minutes to fill.
+
+We use standard time slots for talks to make filling this time easier.  We offer: 40 minute, 25 minute, and 10 minute slots.  We can mix and match slots to fill a meeting.  Some standard meetings are:
+
+* three 25 minute slots
+* one 40 minute slot, one 25 minute slot, one 10 minute slot
+* two 25 minute slots, two 10 minute slots
+* two 40 minute slots (the longer slots can feel tiring so try not to arrange this type of meeting if you can)
+* eight 10 minute slots (we use this for our Feb meeting; it's painful to organise this many speakers so once a year is enough)
+* one 80 minute extravaganza (usually for a practical-type meeting - don't offer someone 80 minutes for a talk)
+
+We don't have to fill 80 minutes, but trying to squeeze in more would be a problem.
+
+Similarly, the slots are a convenience for us to make it easy to work out when a meeting is full, it is not important that a speaker actually fill their slot.  When arranging a talk with a speaker stress to them that they can talk for as long as they like as long as it fits in one of those slots.  We will keep time on the night and stop them if they run over.  Let them know that we'd prefer they take a longer slot and not fill it than take a shorter slot and fail to say everything they wanted.
+
+#### Volunteers
+
+We keep track of speakers on [a google spreadsheet](https://docs.google.com/spreadsheets/d/13RNjhOF1elxSA8yaCLsEZOLf5DnwBuVQehfHJJWLB_E/edit#gid=460069181).  There are usually about 2 to 3 meetings worth of volunteers on this list and with no other constraints we run through the list in first-come, first-served order offering slots.  Our hosts, Skills Matter, prefer details 4 weeks in advance which means we should start looking at the volunteer list about 5 to 6 weeks in advance.  We chase by email where possible, feel free to cc the other organisers if you want to keep them up to date with what is going on.  This will also help if a speaker you chase up for one month defers to a future month as the person organising that meeting will then have the email exchange in their inbox too, ready to pick up.
+
+Filling in the spreadsheet with details of each speaker, their talk, and confirmation status will also help keep other organisers up to date.  In particular the Length, Offered?, and Confirmed? columns are summarised on the "Meetings" sheet to list the speakers for each meeting, and the total runtime.
+
+#### Passing details onto Skills Matter
+
+Our contact at skills matter is currently [Fraser Bradbook](mailto:fraser.bradbrook@skillsmatter.com).  Skills Matter prefer to have details of the meeting about 4 weeks in advance.  If we don't have the details by then it is useful to get in touch anyway to make sure we have a room booked and a registration page ready.  We don't have to pass on all the details in one go.
+
+What Skills Matter need for each speaker is:
+
+> Talk title
+>
+> Talk description
+>
+> Speaker name
+>
+> Speaker bio
+>
+> Twitter handle
+>
+> Speaker photo
+>
+> Skills Matter profile
+
+The first 4 are required, the last 3 are optional but preferred.  The Skills Matter system means that someone can have a member profile (what they log in with and use to attend events) and a speaker profile.  These two profiles have different photo's and bios so even if someone has a member profile Skills Matter want a separate photo and bio for the speaker profile.  They can link the two, but even so the photo and bio are separate.  For repeat speakers you can just point at their existing speaker profile.
+
+#### Email templates
+
+#### Replying to an offer of a talk
+
+> Hi `<human>`,
+>
+> Thanks for volunteering your talk on `<topic>` for LRUG. `<something positive about their talk suggestion - maybe offer some tips if they've asked for them, or pointers to talks we've had recently on similar topics to guide them away from the obvious repetitions>`
+>
+> In terms of timings at LRUG we give speakers a choice of slot timings; 10 minutes, 25 minutes, or 40 minutes.  The slot time is all the time you’d get in front of the group so think about whether or not you want to take Q&A at the end when picking your slot.  It’s not important that you actually fill the slot though - pick the one that fits your talk best.  It’ll be a problem if you need more time than your slot though - we’d rather you took the longer slot and didn’t fill it, than take a shorter slot and rush through things.
+>
+> Looking at the volunteer stack it’s probably 2 months before there’s a free slot.  We offer slots in a first-come, first-served basis, if someone passes we offer it to the next person on the list.  We’re usually in touch with people about 5-6 weeks before the event to confirm details.  `<some details about the stack to set expectations>`
+>
+> Let me know what you think about all this and we’ll get you pencilled in.  Please do take a look at http://readme.lrug.org/ while preparing your talk.  There’s our code of conduct which would apply to your talk, but also tips about colour schemes that work well with our projector and lighting, resolutions for the projector, etc...
+
+An example of a paragraph pointing the volunteer at previous talks on their topic:
+
+> We’ve had a couple of talks about deploying with AWS and docker recently, so it’d be good to review those and work out how yours could be different.  There’s this talk on convox from May: http://lanyrd.com/2016/lrug-may/sfbfqr/, this talk on docker for development from Feb: http://lanyrd.com/2016/lrug-february/sdxymm/, and this one on containers from Sept: http://lanyrd.com/2015/lrug-september/sdrdzp/.  The first two are short talks, and the last one is longer, but hopefully not too onerous to skim through.
+>
+> If you still think there’s something in your topic that we’ve not seen recently then let me know and we can schedule you in.  We’re sure there is something in your topic though: it’s a fairly broad subject and we’ve not had anything about Elastic Beanstalk specifically.
+
+An example of setting expectations around volunteer stack and availability:
+
+> Looking at our list we think there’s a slim chance that there’d be a slot for you in August (8th) but Sept (12th) looks promising.  Failing that the October (10th) meeting is definitely free.  If you needed something booked in right now I could confirm you for Oct now, otherwise I’ll just put you on the list and get in touch when there’s a slot available.  If it was August we’d probably be in touch in the next week or so as folk pass on the slots we offer them.
+
+##### Offering someone a slot when you know how long they're gonna talk for
+
+> Hi `<human>`,
+>
+> There's a `<length>` minute slot at the `<month>` meeting on Monday `<date>` available if you want it for the talk you offered LRUG.
+>
+> If you’re happy to take this slot what I need from you to write it up with Skills Matter and on lrug.org is:
+>
+> About the talk:
+> * Talk title
+> * Talk description - a sentence or two is all we need - feel free to include any links you think might be useful too if you’d like
+> * Talk length `<length>`
+>
+> About you:
+> * Short bio
+> * Twitter handle (if you use twitter)
+> * Photo
+> * Your profile on skills matter (if you have one) - Skills Matter will link your “speaker” profile to your “attendee” profile, but they don’t share details otherwise so we need a new bio/photo etc…
+>
+> You should also take a look at http://readme.lrug.org/ while preparing your talk.  There’s our code of conduct which would apply to your talk, but also tips about colour schemes that work well with our projector and lighting, resolutions for the projector, etc…  Feel free to get in touch with any questions you have too.
+>
+> Reminder: `<length>` minutes is the total time you’ll get on the stage; you don’t have to fill it, but it’ll be a problem if you need more time than that.  If you think your talk will take less than `<length>` minutes and would fit in a shorter slot (25 or 10) then let me know, but I’d rather you kept the longer slot and didn’t fill it than take a shorter slot and rush through things.
+>
+> If for whatever reason you’re unavailable for `<month>`, that’s totally fine.  Just let me know if it’s a “not `<month>`” or “not ever” so I know if I should get in touch again when a slot becomes available at a future meeting.
+>
+> Either way, I’d appreciate hearing back from you as soon as possible (particularly if it’s a no) so I have plenty of time to give other speakers the opportunity to take the slot."
+
+##### Offering someone a slot when you don't know how long they'll talk for
+
+> Hi `<human>`,
+>
+> There's a slot at the `<month>` meeting on Monday `<date>` available if you want it for the talk you offered LRUG.
+>
+> If you’re happy to take this slot what I need from you to write it up with Skills Matter and on lrug.org is:
+>
+> About the talk:
+> * Talk title
+> * Talk description - a sentence or two is all we need - feel free to include any links you think might be useful too if you’d like
+> * Talk length - (to fit in a 10, 25, or 40 minute slot)
+>
+> About you:
+> * Short bio
+> * Twitter handle (if you use twitter)
+> * Photo
+> * Your profile on skills matter (if you have one) - Skills Matter will link your “speaker” profile to your “attendee” profile, but they don’t share details otherwise so we need a new bio/photo etc…
+>
+> You should also take a look at http://readme.lrug.org/ while preparing your talk.  There’s our code of conduct which would apply to your talk, but also tips about colour schemes that work well with our projector and lighting, resolutions for the projector, etc…  Feel free to get in touch with any questions you have too.
+>
+> In terms of timings at LRUG we give speakers a choice of slot timings; 10 minutes, 25 minutes, or 40 minutes.  The slot time is all the time you’d get in front of the group so think about whether or not you want to take Q&A at the end when picking your slot.  It’s not important that you actually fill the slot though - pick the one that fits your talk best.  It’ll be a problem if you need more time than your slot though - I’d rather you took the longer slot and didn’t fill it, than take a shorter slot and rush through things.
+>
+> If for whatever reason you’re unavailable for `<month>`, that’s totally fine.  Just let me know if it’s a “not `<month>`” or “not ever” so I know if I should get in touch again when a slot becomes available at a future meeting.
+>
+> Either way, I’d appreciate hearing back from you as soon as possible (particularly if it’s a no) so I have plenty of time to give other speakers the opportunity to take the slot."
+
+### Dealing with sponsors
+
+We don't need sponsors for our meetings as our relationship with Skills Matter is pretty good.  They provide the room, handle registration, print name badges, and film the talks; all for free.  In return they get attendee details, regular ruby content for their site that draws people to their paid events, and attendees who will spend some money at their bar before and after the meetings.
+
+However, the ruby community is quite buoyant and companies frequently get in touch asking about sponsorship.  Our [README](/) has details for [sponsoring LRUG meetings](/#sponsorship) but it's often not clear from an initial email if the potential sponsor has read that.  Always mention this paart of the readme in your response.
+
+Another key phrase is to remind them that LRUG is not a legal entity with a bank account so it cannot handle cash directly.  A sponsor often wants to give us money and be done with it.  We're a small team of people so our goal is to make the sponsor do as much of the work as possible.  Be as upfront about this as possible.
+
+We offer two types of sponsorship:
+
+#### Food & Drink
+
+This is the least interesting option, but the easiest for the sponsor to arrange.  Food can be ordered directly from a caterer and delivered to Skills Matter by prior arrangement.  Money can be put behind the bar at Skills Matter or the Singer Tavern.  LRUG has ~100 or so attendees (or up to ~160 for popular events like our February lightning talk events) and so it's not cheap to provide food or drinks.  To provide drinks at the bar you will probably want to spend at least £500 to make sure everyone can have at least one drink.  To buy food, the most recent pizza order was for about £500 also.
+
+To arrange for food to be delivered, or to buy drinks to have at the venue put the sponsor in touch with our contact at Skills Matter.  This needs at least a week to organise.
+
+To buy drinks at the pub, tell them to pop in to the pub before the meeting to arrange it and let them know we'll be there about 8pm.  They can almost certainly decide to do this on the day.
+
+#### Giveaways
+
+This is the most interesting option and the one we should push people towards.  What the sponsor provides as prizes is up to them; popular choices are tickets for a conference, or ruby books, or software licenses.  We can offer to help them come up with something if they need help (searching old mailing list posts for `[GIVEAWAY]` is good for tips).  The sponsor should buy the prizes, we'll run the prize draw and provide them with names and email addresses of winners.
+##### Running a prize draw
+
+How we run the prize draw is to setup a google spreadsheet with an attached form; the form should ask for a name and email address.  If there is more than one prize add a drop down or radio button for choosing a prize.  Open the form and announce it to the list with a deadline (usually 1 week).  On the deadline close the form and run a randomization function to pick the correct number of winners.  We then email each winner directly, including the sponsor on the email to let them know they've won and to introduce them to the sponsor.  We make it clear that LRUG's job here is done and their relationship is now with the sponsor.  It's nice to send an email to all the people that didn't win (bcc them all and email yourself) to let them know too.
+
+#### Examples
+
+* [An example announcement for some tickets](http://lists.lrug.org/pipermail/chat-lrug.org/2016-April/011501.html)
+* [An example where there was a choice of prize](http://lists.lrug.org/pipermail/chat-lrug.org/2016-September/011750.html)
+* [An example google spreadsheet and form for running a giveaway](https://docs.google.com/spreadsheets/d/1Ur9OUJzOcJ9uyLFhelK2aUEja1ATXS3BpeLB00LJ1qo/edit#gid=1854423575)
+
+### Hosting
+
+As host you are the face of the meeting for that month.  It may be someone's first LRUG so don't assume that everyone in the room, or the speakers, will have heard everything before or understand what is going on.  Use this list on the night to help things run smoothly:
+
+1. get there for 6 - I’ve started telling folk it’s doors at 6 for talks at 6:30 - I tell the speakers to get there from 6 too so they can test things out.
+2. talk to the AV person, just to say hi and find out if there’s any weird glitches with the projector or microphones or anything
+3. hang out near the front so that it’s obvious who the speakers should talk to
+4. ask them to check their laptops against the projector ahead of time
+5. It’s easiest if the running order is whatever the AV folk have set up which will usually be the order from the Skills Matter site (which might not be the same as the order on lrug.org because … well, TBH I don’t know, but for some reason they sometimes rearrange what I send them).  If all the speakers arrive on time and none of them need to leave early then that order is best.  If someone is late, or someone needs to leave early then it’s fine, I just make sure to let the AV person know the new running order.
+6. remind speakers of their timings. Mention that I’ll be sitting at the front and give them at least a 5 minute warning (or 2 minutes if it’s a 10 minute talk) of when they need to stop.  Ask if they want any other warnings.
+7. start the meeting just after 6:30 - I usually gauge the room to see how full it is - if it seems empty I’ll check with SM at the door - maybe it’s actually a low-attendance meeting, but if there’s loads of names not in I might give it another 5 mins.  SM tell people to mingle in the bar area beforehand so it can be a bit deceptive until just before 6:30.  It might also be a quiet meeting because of transport or weather or  holidays.
+8. start the meeting with some admin announcements:
+   * welcome everyone
+   * mention the next meeting date and any details of the talks if I'm organised enough in advance to know this
+   * invite people to submit talks - hopefully I’ll know some details of the next meeting and what the current lead time is on volunteering which I’ll let you know, but that doesn’t mean they shouldn’t still apply - everyone will get a go eventually if they submit
+   * mention the readme.lrug.org site, explicitly say code of conduct, but also tips for speakers, sponsorship etc…
+   * mention lrug.org and that both of these sites are GitHub so PRs are welcome if you spot anything that should change
+   * mention that there’s a mailing-list and twitter for announcements etc… between meetings
+9. Mention the sponsors if there are any - they might want to say something if they're actually in attendance. Make sure they know to keep it quick.
+10. throw it open to announcements from the floor - sometimes people come up to use the mic, sometimes they do it from their chair.  Either way, I try to make it clear this needs to be short.
+11. welcome each speaker to the stage and get a round of applause to kick them off - this is usually just "our `<nth>` speaker is `<name>` and they'll talk to us about `<whatever their title slide says>`.  round of applause for `<name>`, please" and then slink back to my seat.
+12. during the talk keep time and give the speaker any agreed timing warnings.  Usually this is just a 5min warning, and if it doesn’t look like they’re wrapping up a 1min warning, and a final “you have to stop now!”. I used to wave a hand with the number of fingers for minutes remaining and make a throat cutting motion for “stop”, I've since made an ios note with big sketched 5, 2, and stop signs in and I wave those - I think the bright screen makes it easier to catch the speaker's eye.  The AV folk sometimes have a sign you can borrow for this too though.  Depending on how the other talks have run, I can be a bit subjective here if I think there’s enough time for someone to run over a bit, it’s worth letting the speaker know before they start though and it’s generally better to keep folk to time.
+13. Also be watchful for anything during the talks that might be a bit off-colour.  I pre-seed speakers several time with the code of conduct so hopefully nothing will happen in this regard, but you never know.  If anything does seem off - it’s up to you, either call a halt to it if it’s super-bad, or just mention it to them afterwards and suggest they apologise and change it when/if they post their slides somewhere.  Now there's more of us we can talk about it to come up with a better plan.  The code of conduct does say "you'll be asked to stop" so that might be what we should do.
+14. Be mindful at the end of the talk that you might have to start the clapping - sometimes a talk can just peter out and people aren’t sure so starting the applause gives folk a cue that it’s over.
+15. When they're done I go up and quickly say thanks to the speaker, which means also means I'm there to help them disconnect their laptop and connect the laptop of the next speaker while microphones are swapped over.
+16. After the last talk, wrap up:
+    * thank everyone for coming
+    * remind them of the next meeting date
+    * tell them what the options are for continuing the evening:
+      1. Skills Matter ask me to remind folk that they run a cash bar downstairs where they can mingle with attendees of other meetups that they hosted that night
+      2. I pitch the pub as the option if they want food as well as drinks; it’s The Singer Tavern on the junction of City Road and Worship St.
+    * struggle to come up with a better closing catchphrase than "thanks for coming, byeeeeee!" with a half-hearted wave.
+
+### Comms
+
+We need to communicate the details of the meeting to the LRUG community.  This means:
+
+* passing those details onto skills matter
+* writing them up for lrug.org
+* writing an email announcement to the mailing list
+* doing a tweet announcement
+* doing a follow up reminder tweet on the day of the meeting
+* doing congratulatory follow up tweets after the fact
+* retweeting video or slide announcements from the hosts and speakers
+
+#### TODO: templates and guidance
+
+## Moderating the mailing list
+
+The [mailing list](http://lrug.org/mailing-list) is a [Mailman](https://www.gnu.org/software/mailman/) instance.  We don't have full control of the list software as it's not installed in our shared hosting, it's a service run by our hosting provider on our behalf.  What this means is we don't have access to the code or database directly, but do have full access to the admin interface.
+
+The list is configured so that new members are set to require moderation, but existing members are able to post without requiring moderation.  This probably means about 50% of the list members require moderation.  When we turned moderation on in 2013 there were ~1,000 members; at time of writing there are ~1,500 but I expect that more than 500 people require moderation due to people unsubscribing.  The list will also hold emails for moderation if the size of the email is greater than 100kb (usually because of an attachment).
+
+When someone requires moderation an email is sent to the organisers by mailman with a copy of their email and a link to the moderation interface.  This is also sent to [Harmonia](https://harmonia.io/teams/ukieh7/tasks) which will pick one of the organisers to deal with the email.  Feel free to ignore the email if harmonia doesn't choose you to handle it.
+
+### What to look out for when moderating
+
+Most emails requiring moderation are from people new to the list posting jobs.  Our role is not to fully moderate the list; we're not checking for typos, or avoiding people from making fools of themselves.  We are however looking for obvious [code of conduct](/#code-of-conduct) infractions and people breaking the rules of [job ads](http://lrug.org/posting-jobs).  We also check for people who have clearly replied to the list when they meant to reply just to the poster (usually in reply to a job ad).
+
+If in doubt, talk to the other organisers in our [mailing-list slack channel](https://lrug.slack.com/messages/G1PL86E2H) and get a second opinion.
+
+To moderate you use the mailman interface and choose to accept, defer, delete, or reject.  Usually we accept or reject.  Accept lets the mail through to the list; defer leaves the mail in the moderation queue; delete silently deletes the mail from the moderation queue without posting it; reject deletes the mail from the moderation queue and sends a message to the sender.  If you decide to reject the email you should write a message to the sender explaining why and give them steps to re-write their email so it'll get through moderation a second time.
+
+The rejection messages are only sent to the sender, so it can be useful to give a summary of your rejection notice in the slack channel to keep everyone up to date.  It's likely that harmonia will pick someone else to deal with their 2nd attempt.
+
+## Dealing with incoming mail
+
+We currently only use Harmonia to handle moderation requests.  This means that all other email to the group addresses needs someone to handle it.  For each meeting month Harmonia chooses an organiser to act as the supervisor and it is their duty to pick someone to act as primary email handler for that month.  If you are chosen you should try to reply to emails within a few days.  It is useful to include the group email address as a `<CC>` on your replies so everyone is kept up to date.  You can also mention your responses in in the [organisers slack channel](https://lrug.slack.com/messages/C3RBU6E6B) if you forget.
+
+### Common email topics
+
+#### I posted to the list but can't see it
+
+The mailing list software is set so that only members can post to it.  Emails sent from addresses that are not signed up to the list are silently deleted by the list.  This can cause confusion when someone is signed up using one email address (their personal one for example) and they try to post from another one (their work one) and it doesn't come through.  First thing to do is check the member list to see if you can find them, if not reply along these lines and suggest they sign up again, or post from their alternate address.
+
+#### TODO: more common topics not covered by the speakers and sponsors sections above
+
+### TODO: template responses

--- a/organising/index.md
+++ b/organising/index.md
@@ -7,6 +7,7 @@ title: organising LRUG
 
 LRUG doesn't happen spontaneously every month it takes care and attention to detail to make sure it runs smoothly.  These pages are here to help you if it's your turn to organise one of our meetings.
 
+ * [Useful links](#useful-links)
  * [Being responsible for a meeting](#being-responsible-for-a-meeting)
    * [Arranging speakers](#arranging-speakers)
    * [Dealing with sponsors](#dealing-with-sponsors)
@@ -14,6 +15,14 @@ LRUG doesn't happen spontaneously every month it takes care and attention to det
    * [Comms](#comms)
  * [Moderating the mailing list](#moderating-the-mailing-list)
  * [Dealing with incoming mail](#dealing-with-incoming-mail)
+
+## Useful links
+
+* [Slack](https://lrug.slack.com/) - this is where all the organisers hang out; you can ask for help in here
+* [Harmonia](https://harmonia.io/teams/ukieh7/tasks) - we use harmonia to randomly assign organisers to recurring tasks and adhoc events (like moderating email)
+* [Schedule spreadsheet](https://docs.google.com/spreadsheets/d/13RNjhOF1elxSA8yaCLsEZOLf5DnwBuVQehfHJJWLB_E/edit#gid=460069181) - this spreadsheet has a summary of all the meetings, the volunteer speakers list, a list of potential sponsors, and some email templates.
+* [Mailing list admin interface](http://lists.lrug.org/admin.cgi/chat-lrug.org) and [moderation interface](http://lists.lrug.org/admindb.cgi/chat-lrug.org) - this is where we deal with the mailing list
+* [Our contact at Skills Matter: Fraser Bradbrook](mailto:fraser.bradbrook@skillsmatter.com) - this is who we pass details on to for our meetings and who we get in touch with for other questions about the venue and hosting
 
 ## Being responsible for a meeting
 


### PR DESCRIPTION
This is a first pass at providing some documentation for organisers.  This
pulls together stuff written up in slack, in emails, and from my brain.
It's far from complete, but should serve as a good starting point.

It may be easier to review by looking at [the rendered version](https://github.com/lrug/lrug.github.io/blob/organiser-documentation/organising/index.md)

This is totally WIP as there are TODO's all over it.  It's also just a huge wall of text, perhaps it would work better as separate documents?

