### PR TITLE
Link to main site on first mention of 'LRUG'

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: README.lrug
 
 # README.lrug
 
-LRUG is a London-based community for anyone who is interested in the Ruby programming language, especially beginners.
+[LRUG](http://lrug.org) is a London-based community for anyone who is interested in the Ruby programming language, especially beginners.
 
 LRUG provides [online](http://lrug.org/mailing-list) and [offline](http://lanyrd.com/series/lrug/) opportunities to:
 


### PR DESCRIPTION
I noticed that we don't really link to the homepage in this README, so my proposal is to make the first mention of 'LRUG' a link to the homepage.

This also acts as an acronym definition (doing HTML abbreviations is a markdown extension that probably isn't supported), seeing as we don't define the acronym in this document either. It is helpfully at the top of the LRUG homepage though.