### PR TITLE
Rename default branch to `main`

### DIFF
--- a/organising/organising-a-meeting.md
+++ b/organising/organising-a-meeting.md
@@ -188,7 +188,7 @@ The short version is that you need to:
 After the meeting, we need to follow up:
 
 1. We should [edit the videos](/organising/video-editing) for the talks and post them online
-2. Email the speakers to thank them for their talks and invite them to add [coverage links](https://github.com/lrug/lrug.org/tree/master/data/coverage) for their talks (write ups, slides, relevant repos, other videos, etc...)
+2. Email the speakers to thank them for their talks and invite them to add [coverage links](https://github.com/lrug/lrug.org/tree/main/data/coverage) for their talks (write ups, slides, relevant repos, other videos, etc...)
 3. Tweet about the videos once they are posted
 
 {% include organising-links.md %}


### PR DESCRIPTION
This PR is more a ceremonial placeholder than anything, since it doesn’t look like we refer to this repo’s default branch anywhere. But there is a stray reference to lrug/lrug.org’s default branch, which we’ll need to change once lrug/lrug.org#246 is merged.