### PR TITLE
2023 revisions

### DIFF
--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ We want LRUG to be a diverse and inclusive community, united by an interest in R
 
 ## Code of Conduct
 
-It’s of primary importance that everyone who wants to participate feels safe and welcome. When participating in LRUG, either online or offline, at an in-person event, or at the pub afterwards, we expect you to:
+It’s of primary importance that everyone who wants to participate feels safe and welcome. When participating in LRUG, either online or in-person at [a meeting](#meetings), or [the pub afterwards](#after-the-talks), we expect you to:
 
  * behave respectfully towards other people — they’re real humans, just like you
  * be considerate of people’s time and attention

--- a/index.md
+++ b/index.md
@@ -5,9 +5,9 @@ title: README.lrug
 
 # README.lrug
 
-[LRUG](http://lrug.org) is a London-based community for anyone who is interested in the Ruby programming language, especially beginners.
+[LRUG](https://lrug.org) is a London-based community for anyone who is interested in the Ruby programming language, especially beginners.
 
-LRUG provides [online](http://lrug.org/mailing-list) and [offline](http://lrug.org/meetings) opportunities to:
+LRUG provides [online](https://lrug.org/mailing-list) and [offline](https://lrug.org/meetings) opportunities to:
 
  * discuss Ruby and related topics
  * socialise with friendly people who are interested in Ruby
@@ -82,7 +82,7 @@ During a meeting, the members of the organising team will make themselves known 
 
 ## Meetings
 
-We meet once a month usually on **the second Monday of the month** (e.g. the Monday that falls between the **8th** and **14th** of the month). Occasionally we have to move the meeting from this schedule, but we'll let you know via [the mailing list](http://lrug.org/mailing-list) with plenty of time if we do.
+We meet once a month usually on **the second Monday of the month** (e.g. the Monday that falls between the **8th** and **14th** of the month). Occasionally we have to move the meeting from this schedule, but we'll let you know via [the mailing list](https://lrug.org/mailing-list) with plenty of time if we do.
 
 The meetings aim to open the doors at **6pm** for some networking until **6:30pm** when we start the meeting formally with some admin information. We roll on through [the talks](#talks) without a break, and aim to finish by **8pm**. If it's an in-person event, we encourage people to go to [a nearby pub](#after-the-talks) to discuss the meeting and do more networking.
 
@@ -90,9 +90,9 @@ We do not currently have a permanent home for LRUG meetings, and so we tour the 
 
 To stay informed about our upcoming meetings you can:
 
- * subscribe to [the mailing list](http://lrug.org/mailing-list)
- * subscribe to [the lrug.org meetings RSS](http://lrug.org/rss/meetings)
- * subscribe to [our calendar](http://lrug.org/meeting-calendar)
+ * subscribe to [the mailing list](https://lrug.org/mailing-list)
+ * subscribe to [the lrug.org meetings RSS](https://lrug.org/rss/meetings)
+ * subscribe to [our calendar](https://lrug.org/meeting-calendar)
  * follow `@lrug` on [mastodon](https://ruby.social/@lrug) and, begrudgingly, on [twitter](https://twitter.com/lrug)
  * follow the [LRUG account on eventbrite](https://www.eventbrite.com/o/london-ruby-user-group-28936506513)
 
@@ -172,7 +172,7 @@ We always need venues, and if you think your office could host us please fill ou
  1. put your logo in the "Hosted By" side-bar on the relevant meeting page on [lrug.org](https://lrug.org)
  2. mention the specifics of your venue + sponsorship in the main details of the relevant meeting page on [lrug.org](https://lrug.org)
  3. add your logo to the [meeting sponsors list](https://lrug.org/sponsors/#meeting-sponsorship) on [lrug.org](https://lrug.org/)
- 4. mention the venue + sponsorship in the meeting announcement email on [the mailing list](http://lrug.org/mailing-list)
+ 4. mention the venue + sponsorship in the meeting announcement email on [the mailing list](https://lrug.org/mailing-list)
  5. mention the venue + sponsorship when we post to [@lrug](https://ruby.social/@lrug) about the meeting at least once to announce it and once on the day as a reminder (we might also do the same on _ugh_ twitter)
  6. thank you at the start of the meeting, and give you time during the meeting to talk to the group
 
@@ -182,7 +182,7 @@ We welcome sponsors of the meeting itself. In return for your sponsorship LRUG w
 
  1. put your logo in the sponsor side-bar on the relevant meeting page on [lrug.org](https://lrug.org)
  2. mention the specifics of your sponsorship in the main details of the relevant meeting page on [lrug.org](https://lrug.org)
- 3. mention the sponsorship in the meeting announcement email on [the mailing list](http://lrug.org/mailing-list)
+ 3. mention the sponsorship in the meeting announcement email on [the mailing list](https://lrug.org/mailing-list)
  4. add your logo to the [other sponsors list](https://lrug.org/sponsors/#other-sponsorship) on [lrug.org](https://lrug.org/)
  4. mention the sponsorship from [@lrug](https://ruby.social/@lrug) at least once to announce it and once on the day as a reminder (we might also do the same on _ugh_ twitter)
  5. mention you at the start of the meeting, and make sure you have 30 seconds or so during our announcements section to talk to the group
@@ -193,7 +193,7 @@ Things that have worked well in the past are [give-aways](#sponsor-a-give-away),
 
 #### Sponsor a give-away
 
-Running a give-away is a real favourite among attendees and allows you to control the budget you have to spend as you see fit. For example [in September 2016](http://lrug.org/meetings/2016/september/) we ran a give-away of 20 books and [in May 2016](http://lrug.org/meetings/2016/may/) we gave-away 5 tickets to a popular conference. We will run the logistics of the give-away through the mailing list and announce the winners on the night. You arrange to pay for the prizes and deliver them to the winners.
+Running a give-away is a real favourite among attendees and allows you to control the budget you have to spend as you see fit. For example [in September 2016](https://lrug.org/meetings/2016/september/) we ran a give-away of 20 books and [in May 2016](https://lrug.org/meetings/2016/may/) we gave-away 5 tickets to a popular conference. We will run the logistics of the give-away through the mailing list and announce the winners on the night. You arrange to pay for the prizes and deliver them to the winners.
 
 #### Sponsor food (pizza)
 
@@ -223,7 +223,7 @@ welcome. There are a number of ways of contributing:
     pull-request at this document's
     [Github repository](https://github.com/lrug/lrug.github.io/)
  2. By proposing or suggesting your changes on the LRUG
-    [mailing list](http://lrug.org/mailing-list).
+    [mailing list](https://lrug.org/mailing-list).
  3. By privately contacting one of the
     [organisation team](#organisation-team).
 

--- a/index.md
+++ b/index.md
@@ -84,7 +84,9 @@ During a meeting, the members of the organising team will make themselves known 
 
 We meet once a month usually on **the second Monday of the month** (e.g. the Monday that falls between the **8th** and **14th** of the month). Occasionally we have to move the meeting from this schedule, but we'll let you know via [the mailing list](https://lrug.org/mailing-list) with plenty of time if we do.
 
-The meetings aim to open the doors at **6pm** for some networking until **6:30pm** when we start the meeting formally with some admin information. We roll on through [the talks](#talks) without a break, and aim to finish by **8pm**. If it's an in-person event, we encourage people to go to [a nearby pub](#after-the-talks) to discuss the meeting and do more networking.
+We try to meet in-person somewhere in central London, usually around the Old Street / Shoreditch / City area, although sometimes further afield depending on who can host us.  If we cannot find a venue, or there are other reasons for us not to meet in-person, we run the meetings remotely usually via zoom.  We don't currently run "hybrid" meetings with in-person and remove attendees.
+
+The meetings aim to open the doors at **6pm** for some networking until **6:30pm** when we start the meeting formally with some admin information. We roll on through [the talks](#talks) without a break, and aim to finish by **8pm**. If it's an in-person event, we encourage people to go to [a nearby pub](#after-the-talks) to discuss the meeting and do more networking.  If it's a remote event, we usually leave the call running for people to chat afterwards, although it is a diminished experience for networking.
 
 We do not currently have a permanent home for LRUG meetings, and so we tour the offices of various companies around London. In the most generous cases, this can mean there is food + drink available at the meeting, but you shouldn't rely on it. See our details on [sponsoring](#sponsoring) below for more details.
 

--- a/index.md
+++ b/index.md
@@ -89,7 +89,10 @@ To stay informed about our upcoming meetings you can:
 
 Most of our meetings have talks from community members and we're always looking for people to give a talk. If you'd like to give a talk you should email [talks@lrug.org](mailto:talks@lrug.org) and suggest it.
 
-Our goal is to accept any offered talk. If your talk is obviously about Ruby there's no question about it; you can definitely give your talk. If it's not so obviously about Ruby we'll have a discussion first to see what the hook is for Rubyists. We're quite an open-minded group, so the hook doesn't have to be that clear. In the unlikely event that it turns out that LRUG isn't a good home for your talk, we'll do our best to come up with some alternative ideas for places you could give it.
+Our goal is to accept any offered talk. There's more discussion on [subject matter below](#subject-matter), but in brief:
+
+* if your talk is obviously about Ruby there's no question about it; you can definitely give your talk.
+* if it's not so obviously about Ruby we'll have a discussion first to see what the hook is for Rubyists. We're quite an open-minded group, so the hook doesn't have to be that clear. In the unlikely event that it turns out that LRUG isn't a good home for your talk, we'll do our best to come up with some alternative ideas for places you could give it.
 
 #### Scheduling
 
@@ -101,9 +104,11 @@ If there is a specific future meeting that would be most convenient for you, let
 
 #### Subject Matter
 
+As [we said above](#talks), LRUG is a big tent for ideas. What connects our attendees is a love for the Ruby programming language, but that's not all we're interested in hearing about. Explicitly: we _don't_ need the talk to be directly about the Ruby programming language. If you are drawn to the group, and find your subject interesting, chances are we will too. Suggest your topic and we'll work with you to make sure it's a good fit.
+
 LRUG is a mixed-ability crowd; we have talks from first-timers just learning Ruby all the way up to people that have been using it for years. This means you can pitch your talk at any level and someone will get something out of it. It's also a mostly technical crowd, so don't shy away from getting into the nitty gritty of your topic. We'd prefer an in-depth discussion of a single aspect to a shallow overview of the whole thing.
 
-Your talk should observe the code of conduct. Any talks that don't will be stopped and the speaker asked to leave.
+**Your talk should observe the [code of conduct](#code-of-conduct)**. Any talks that don't will be stopped and the speaker asked to leave.
 
 If you are using the projector you should favour large fonts and a high contrast colour scheme with dark text on a light background in anything you show. The default settings for most presentation applications are a safe bet, but you might have to re-configure your terminal or editor if you are using those for anything. Also note that while the projector will cope with most screen resolutions, it works best at 1024x768. Most presentation applications will automatically resize, but you might want to check your slides at that resolution.
 

--- a/index.md
+++ b/index.md
@@ -26,25 +26,30 @@ We want LRUG to be a diverse and inclusive community, united by an interest in R
      * [Timing](#timing)
    * [After The Talks](#after-the-talks)
  * [Sponsorship](#sponsorship)
+   * [Meeting Sponsorship](#meeting-sponsorship)
+   * [Other Sponsorship Opportunities](#other-sponsorship-opportunities)
+     * [Sponsor a give-away](#sponsor-a-give-away)
+     * [Sponsor food (pizza)](#sponsor-food-pizza)
+     * [Sponsor drinks](#sponsor-drinks)
  * [About This Document](#about-this-document)
    * [License](#license)
 
 ## Code of Conduct
 
-It’s of primary importance that everyone who wants to participate feels safe and welcome. When participating in LRUG, either online or offline, at Skills Matter or at the pub afterwards, we expect you to:
+It’s of primary importance that everyone who wants to participate feels safe and welcome. When participating in LRUG, either online or offline, at an in-person event, or at the pub afterwards, we expect you to:
 
  * behave respectfully towards other people — they’re real humans, just like you
  * be considerate of people’s time and attention
  * contribute positively and constructively to discussions (online or in-person)
 
-On the mailing list, we want to maintain a high signal-to-noise ratio and while the organisers will step in as soon as they see poor behaviour, we encourage you to say something if you see it first.  So please:
+On the mailing list, we want to maintain a high signal-to-noise ratio and while the organisers will step in as soon as they see poor behaviour, we encourage you to say something if you see it first. So please:
 
  * lead by example — if a discussion is devolving into snark and name-calling, either let it die or raise the tone
  * keep standards high — if someone acts disrespectfully, make that crystal clear to them
 
 ### Incident Handling
 
-We want everyone to feel welcome at LRUG, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. Accordingly, we will not tolerate harassment of our members in any form; not at the talks, not at the pub after the talks, or any other LRUG social meeting; not on Twitter or on any other online media.
+We want everyone to feel welcome at LRUG, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. Accordingly, we will not tolerate harassment of our members in any form; not at the talks, not at the pub after the talks, or any other LRUG social meeting; not on the mailing list or on any other online media.
 
 Harassment includes invasions of personal space, exclusionary jokes/comments, and sexual language and imagery in talks, but this list is non-exhaustive: if you make anyone feel uncomfortable or unwelcome, you will be asked to leave.
 
@@ -66,16 +71,22 @@ LRUG is run by a team of volunteers from the London Ruby community:
  * Alessandro Proserpio ([alessandro.proserpio@lrug.org](mailto:alessandro.proserpio@lrug.org))
  * [Murray Steele](http://h-lame.com/) ([@hlame](https://ruby.social/@hlame), [murray.steele@lrug.org](mailto:murray.steele@lrug.org))
 
-Feel free to contact one of the organisers directly using the details above if you have any questions or comments about LRUG.  As well as the individual details above, the following group contact details are available that will get in touch with all the organisers:
+Feel free to contact one of the organisers directly using the details above if you have any questions or comments about LRUG. As well as the individual details above, the following group contact details are available that will get in touch with all the organisers:
 
  * [talks@lrug.org](mailto:talks@lrug.org) - to volunteer a [talk](#talks) or to find out about giving a talk
  * [sponsors@lrug.org](mailto:sponsors@lrug.org) - to find out about [sponsoring](#sponsorship) LRUG events
  * [complaints@lrug.org](mailto:complaints@lrug.org) - if you need to report an incident in relation to our [code of conduct](#code-of-conduct)
  * [organisers@lrug.org](mailto:organisers@lrug.org) - for general enquiries about LRUG
 
+During a meeting, the members of the organising team will make them selves known at the start so you can talk to them directly should anything occur during the meeting.
+
 ## Meetings
 
-We meet once a month at [Skills Matter](https://skillsmatter.com/locations/264-skills-matter-codenode), usually on the second Monday. There are typically [three talks](#talks) and then we go to [the pub](#after-the-talks). There’s always tea and coffee at Skills Matter, and sometimes there’ll be pizza; beer is limited to the pub afterwards.
+We meet once a month usually on **the second Monday of the month** (e.g. the Monday that falls between the **8th** and **14th** of the month). Occasionally we have to move the meeting from this schedule, but we'll let you know via [the mailing list](http://lrug.org/mailing-list) with plenty of time if we do.
+
+The meetings aim to open the doors at **6pm** for some networking until **6:30pm** when we start the meeting formally with some admin information. We roll on through [the talks](#talks) without a break, and aim to finish by **8pm**. If it's an in-person event, we encourage people to go to [a nearby pub](#after-the-talks) to discuss the meeting and do more networking.
+
+We do not currently have a permanent home for LRUG meetings, and so we tour the offices of various companies around London. In the most generous cases, this can mean there is food + drink available at the meeting, but you shouldn't rely on it. See our details on [sponsoring](#sponsoring) below for more details.
 
 To stay informed about our upcoming meetings you can:
 
@@ -98,7 +109,7 @@ Our goal is to accept any offered talk. There's more discussion on [subject matt
 
 Slots for talks are first-come, first-served. Once you've decided to give your talk we'll let you know when a free slot will be available at a meeting. We usually have two or three talks per meeting, so if there are four people on our list of volunteers when you offer your talk it's most likely that the third meeting is the one we'd schedule you for. Of course, people drop out or aren't available for a specific meeting so you might get a slot sooner.
 
-Our hosts, Skills Matter, request a four-week lead time for events. This means we try to arrange meetings about five or six weeks in advance. Combined with the depth of the volunteer stack, this can mean a three to four month gap between you proposing a talk and getting to give it to the group.
+Ideally we have some talks scheduled for the next meeting so we can announce them at the start of the current meeting. This means we try to arrange meetings about five or six weeks in advance. Combined with the depth of the volunteer stack, in extreme cases, this could mean a three to four month gap between you proposing a talk and getting to give it to the group.
 
 If there is a specific future meeting that would be most convenient for you, let us know and we'll do our best to accommodate that.
 
@@ -110,7 +121,7 @@ LRUG is a mixed-ability crowd; we have talks from first-timers just learning Rub
 
 **Your talk should observe the [code of conduct](#code-of-conduct)**. Any talks that don't will be stopped and the speaker asked to leave.
 
-If you are using the projector you should favour large fonts and a high contrast colour scheme with dark text on a light background in anything you show. The default settings for most presentation applications are a safe bet, but you might have to re-configure your terminal or editor if you are using those for anything. Also note that while the projector will cope with most screen resolutions, it works best at 1024x768. Most presentation applications will automatically resize, but you might want to check your slides at that resolution.
+If the event is in-person you should favour large fonts and a high contrast colour scheme with dark text on a light background in anything you show. The default settings for most presentation applications are a safe bet, but you might have to re-configure your terminal or editor if you are using those to show anything. We don't have a fixed venue, so we can't guarantee what resolution a projector will cope with. These days a 16:9 resolution is likely to work best (e.g. 1920x1080), most presentation applications will automatically scale to whatever resolution a 2nd screen has, but you might want to check your slides at that resolution just in case.
 
 #### Resources for Speakers
 
@@ -140,39 +151,57 @@ To leave plenty of time for you to over-run, answer questions, and faff about wi
 
 ### After The Talks
 
-When the talks are finished, usually around 8pm, most of the group head over to [Singer Tavern](http://singertavern.com/). This part of the meeting is your opportunity to socialise with other LRUG members and speak with the presenters about their talks.
+When the talks are finished, usually around 8pm, most of the group head over to a local pub. This part of the meeting is your opportunity to socialise with other LRUG members and speak with the presenters about their talks.
 
-Just because we're in a pub doesn't mean you have to drink alcohol.  If you do choose to drink alcohol we encourage you to explore the food menu and drink responsibly.
+Just because we're in a pub doesn't mean you have to drink alcohol. If you do choose to drink alcohol we encourage you to explore the food menu and drink responsibly.
 
-Although the venue for this part of the meeting is a pub and therefore feels more informal, be aware that the code of conduct still applies.
+Although the venue for this part of the meeting is a pub and therefore feels more informal, be aware that the [code of conduct](#code-of-conduct) still applies.
 
 ## Sponsorship
 
-LRUG is hosted by [Skills Matter](http://skillsmatter.com/) who provide the venue; make tea, coffee, & water available during the talks; film the talks; and handle registration. We don't currently need venue sponsorship or an alternate venue.
+Most importantly, we do not have a permanent home and so we need sponsorship in the form of [venues](#venue-sponsorship). We have opportunities for helping out in [other ways](#other-sponsorship-opportunities) if you'd like to enrich the LRUG experience in some way.
+
+If you would like to provide sponsorship you should email [sponsors@lrug.org](mailto:sponsors@lrug.org) to find out when the next available sponsorship slot is and arrange the details.
+
+### Venue Sponsorship
+
+LRUG does not have currently have a permanent venue — we are kindly hosted by [an array of friendly companies](https://lrug.org/sponsors/#meeting-sponsorship) across London. They let us into their office, provide some kind of AV setup, put in place any entry requirements, and, occasionally, even provide food + drink for attendees.
+
+We always need venues, and if you think your office could host us please fill out [this fairly detailed survey](https://forms.gle/vkzD11BgC15eoHdT6) to help us understand your venue, how we'd use it, and what we need to do to book it.
+
+ 1. put your logo in the "Hosted By" side-bar on the relevant meeting page on [lrug.org](https://lrug.org)
+ 2. mention the specifics of your venue + sponsorship in the main details of the relevant meeting page on [lrug.org](https://lrug.org)
+ 3. add your logo to the [meeting sponsors list](https://lrug.org/sponsors/#meeting-sponsorship) on [lrug.org](https://lrug.org/)
+ 4. mention the venue + sponsorship in the meeting announcement email on [the mailing list](http://lrug.org/mailing-list)
+ 5. mention the venue + sponsorship when we post to [@lrug](https://ruby.social/@lrug) about the meeting at least once to announce it and once on the day as a reminder (we might also do the same on _ugh_ twitter)
+ 6. thank you at the start of the meeting, and give you time during the meeting to talk to the group
+
+### Other Sponsorship Opportunities
 
 We welcome sponsors of the meeting itself. In return for your sponsorship LRUG will:
 
- 1. put your logo in the sponsor side-bar on the relevant meeting page on [lrug.org](http://lrug.org)
- 2. mention the specifics of your sponsorship in the main details of the relevant meeting page on [lrug.org](http://lrug.org)
+ 1. put your logo in the sponsor side-bar on the relevant meeting page on [lrug.org](https://lrug.org)
+ 2. mention the specifics of your sponsorship in the main details of the relevant meeting page on [lrug.org](https://lrug.org)
  3. mention the sponsorship in the meeting announcement email on [the mailing list](http://lrug.org/mailing-list)
- 4. tweet about the sponsorship from [@lrug](https://twitter.com/lrug) at least once to announce it and once on the day as a reminder
+ 4. add your logo to the [other sponsors list](https://lrug.org/sponsors/#other-sponsorship) on [lrug.org](https://lrug.org/)
+ 4. mention the sponsorship from [@lrug](https://ruby.social/@lrug) at least once to announce it and once on the day as a reminder (we might also do the same on _ugh_ twitter)
  5. mention you at the start of the meeting, and make sure you have 30 seconds or so during our announcements section to talk to the group
 
-LRUG is not a legal entity and we don't have a bank account. So if you decide to sponsor a meeting we'll leave it to you to arrange and pay for things directly. We're there to help with any questions and suggestions though. We have three types of sponsorship available at each meeting, and you can choose to provide any or all in combination:
+LRUG is not a legal entity and we don't have a bank account. So if you decide to sponsor a meeting we'll leave it to you to arrange and pay for things directly. We're there to help with any questions and suggestions though.
 
-### Sponsor a give-away
+Things that have worked well in the past are [give-aways](#sponsor-a-give-away), [food](#sponsor-food-pizza), and [drinks](#sponsor-drinks). You can choose to provide any or all in combination, but we're open to any other ideas for how to enrich the experience for our attendees.
+
+#### Sponsor a give-away
 
 Running a give-away is a real favourite among attendees and allows you to control the budget you have to spend as you see fit. For example [in September 2016](http://lrug.org/meetings/2016/september/) we ran a give-away of 20 books and [in May 2016](http://lrug.org/meetings/2016/may/) we gave-away 5 tickets to a popular conference. We will run the logistics of the give-away through the mailing list and announce the winners on the night. You arrange to pay for the prizes and deliver them to the winners.
 
-### Sponsor food (pizza)
+#### Sponsor food (pizza)
 
-If you'd like to feed LRUG attendees before the meeting we normally suggest Pizza - it's a safe bet for all tastes and easy to arrange in vegetarian and vegan options. We get around 60-100 attendees for an average meeting and it's sensible to budget £400-600 for pizza. We'll get some preferred vendor details from Skills Matter (we've used Firezza pizza in the past). You pay the vendor directly and arrange to have it delivered to Skills Matter on the day in time for the meeting. We'll make sure Skills Matter know to expect it.
+If you'd like to feed LRUG attendees before the meeting we normally suggest Pizza - it's a safe bet for all tastes and easy to arrange in vegetarian and vegan options. We get around 30-50 attendees for an average meeting and it's sensible to budget £200-300 for pizza. During the Skills Matter days we used Firezza pizza, but others are available. You pay the vendor directly and arrange to have it delivered to our venue on the day in time for the meeting start at 6pm. We'll make sure the venue know to expect it. We expect you to cater such that at least half of the food is suitable for vegetarians and vegans.
 
-### Sponsor drinks
+#### Sponsor drinks
 
-Skills Matter run a licensed bar that's open until 10pm. A good number of attendees like to have a drink there after the meeting, and we will put you in touch with Skills Matter who can set up a tab at the bar in the venue for the amount you specify and invoice you afterwards. It's worth budgeting £400-600 to provide drinks and we ask that you make this available as a bar tab to allow people to choose non-alcoholic drinks if they prefer.
-
-If you would like to provide sponsorship you should email [sponsors@lrug.org](mailto:sponsors@lrug.org) to find out when the next available sponsorship slot is and arrange the details.
+The easiest option here is to send someone with a card to the meeting, and have them create a tab in the pub afterwards. This way you can easily control your spend with a limit. Some of our venues _may_ allow for you to ship some drinks to them so attendees can drink something during the event. We can put you in touch with the venue in this case. We get around 30-50 attendees for an average meeting so it's worth budgeting £200-300 to provide drinks in a pub, probably less if you ship to the venue. Either way we expect that you make available both alcoholic and non-alcoholic options.
 
 ## About this document
 

--- a/index.md
+++ b/index.md
@@ -59,12 +59,12 @@ to a member of the [organisation team](#organisation-team).
 
 LRUG is run by a team of volunteers from the London Ruby community:
 
- * [James Adam](http://lazyatom.com) ([@lazyatom](https://twitter.com/lazyatom), [james.adam@lrug.org](mailto:james.adam@lrug.org))
- * [Frederick Cheung](https://spacevatican.org/) ([@fglc2](https://twitter.com/fglc2), [frederick.cheung@lrug.org](mailto:frederick.cheung@lrug.org))
- * [Paolo Fabbri](https://internetblacksmith.dev/) ([@jabawack81](https://twitter.com/jabawack81), [paolo.fabbri@lrug.org](mailto:paolo.fabbri@lrug.org))
- * [Chris Lowis](http://blog.chrislowis.co.uk/) ([@chrislowis](https://twitter.com/chrislowis), [chris.lowis@lrug.org](mailto:chris.lowis@lrug.org))
+ * [James Adam](http://lazyatom.com) ([@lazyatom](https://ruby.social/@james), [james.adam@lrug.org](mailto:james.adam@lrug.org))
+ * [Frederick Cheung](https://spacevatican.org/) ([@fglc2](https://ruby.social/@fglc2), [frederick.cheung@lrug.org](mailto:frederick.cheung@lrug.org))
+ * [Paolo Fabbri](https://internetblacksmith.dev/) ([@jabawack81](https://mastodon.social/@jabawack81), [paolo.fabbri@lrug.org](mailto:paolo.fabbri@lrug.org))
+ * [Chris Lowis](http://blog.chrislowis.co.uk/) ([@chrislowis](https://ruby.social/@chrislowis), [chris.lowis@lrug.org](mailto:chris.lowis@lrug.org))
  * Alessandro Proserpio ([alessandro.proserpio@lrug.org](mailto:alessandro.proserpio@lrug.org))
- * [Murray Steele](http://h-lame.com/) ([@hlame](https://twitter.com/hlame), [murray.steele@lrug.org](mailto:murray.steele@lrug.org))
+ * [Murray Steele](http://h-lame.com/) ([@hlame](https://ruby.social/@hlame), [murray.steele@lrug.org](mailto:murray.steele@lrug.org))
 
 Feel free to contact one of the organisers directly using the details above if you have any questions or comments about LRUG.  As well as the individual details above, the following group contact details are available that will get in touch with all the organisers:
 

--- a/index.md
+++ b/index.md
@@ -78,7 +78,7 @@ Feel free to contact one of the organisers directly using the details above if y
  * [complaints@lrug.org](mailto:complaints@lrug.org) - if you need to report an incident in relation to our [code of conduct](#code-of-conduct)
  * [organisers@lrug.org](mailto:organisers@lrug.org) - for general enquiries about LRUG
 
-During a meeting, the members of the organising team will make them selves known at the start so you can talk to them directly should anything occur during the meeting.
+During a meeting, the members of the organising team will make themselves known at the start so you can talk to them directly should anything occur during the meeting.
 
 ## Meetings
 

--- a/index.md
+++ b/index.md
@@ -79,11 +79,11 @@ We meet once a month at [Skills Matter](https://skillsmatter.com/locations/264-s
 
 To stay informed about our upcoming meetings you can:
 
- * subscribe to [our calendar](http://lrug.org/meeting-calendar)
- * follow the [LRUG series on lanyrd](http://lanyrd.com/series/lrug/)
- * follow [@lrug](http://twitter.com/lrug)
  * subscribe to [the mailing list](http://lrug.org/mailing-list)
  * subscribe to [the lrug.org meetings RSS](http://lrug.org/rss/meetings)
+ * subscribe to [our calendar](http://lrug.org/meeting-calendar)
+ * follow `@lrug` on [mastodon](https://ruby.social/@lrug) and, begrudgingly, on [twitter](https://twitter.com/lrug)
+ * follow the [LRUG account on eventbrite](https://www.eventbrite.com/o/london-ruby-user-group-28936506513)
 
 ### Talks
 

--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ On the mailing list, we want to maintain a high signal-to-noise ratio and while 
 
 ### Incident Handling
 
-We want everyone to feel welcome at LRUG, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. Accordingly, we will not tolerate harassment of our members in any form; not at the talks, not at the pub after the talks, or any other LRUG social meeting; not on the mailing list or on any other online media.
+We want everyone to feel welcome at LRUG, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. Accordingly, we will not tolerate harassment of our members in any form; not at the talks, not at the pub after the talks, or any other LRUG social meeting; not on the mailing list or on any other online platform.
 
 Harassment includes invasions of personal space, exclusionary jokes/comments, and sexual language and imagery in talks, but this list is non-exhaustive: if you make anyone feel uncomfortable or unwelcome, you will be asked to leave.
 

--- a/organising/video-editing.md
+++ b/organising/video-editing.md
@@ -19,7 +19,7 @@ LRUG month year - speaker name - talk title
 
 ## Assets
 
- 1. [the lrug logo](http://assets.lrug.org/images/elrug_medium.jpg)
+ 1. [the lrug logo](https://assets.lrug.org/images/el-rug-logo.png)
  2. "44th Street medium" jingle - available in the "Audio" tab, there's 3 a short, medium, and long version.  We want the medium one that's 19 seconds long
  3. "Gradient black" title - available in the "Titles" tab
  4. "Futura Medium" font - it's what the title uses by default

--- a/organising/video-editing.md
+++ b/organising/video-editing.md
@@ -27,40 +27,75 @@ LRUG month year - speaker name - talk title
 
 ## Intro
 
- * `13.0` seconds of the LRUG logo - make sure the cropping is set to "fit"
- * `19.1` seconds of "44th street medium" jingle as audio layer - this is the actual length of this jingle, no need to stretch or cut
- * `6.3` seconds of the "gradient black" title
-   * Main: LRUG
-   * Subtitle: `month year`
- * `12.8` seconds of the "gradient black" title
-   * Main: `name of the speaker`
-   * Subtitle: `title of talk`
-   * If the talk has a _very_ long title, you might need to do something special
+ * Video Track - starting from 0
+   * `13.0` seconds of the LRUG logo - make sure the cropping is set to "fit"
+   * the main video of the talk, starting after the logo
+ * Audio Track - starting from 0
+   * `19.1` seconds of "44th street medium" jingle as audio layer - this is the actual length of this jingle, no need to stretch or cut
+   * the main audio of the talk, starting after the logo
+
+   Yes! This means the jingle audio layers over the talk audio.  The jingle has started to fade out by then though, so usually this is ok - you can pick the exact start of the main talk video to compensate for it if you need to though.
+ * Text track - starting from 0
+   * `6.3` seconds of the "gradient black" title
+     * Main: LRUG
+     * Subtitle: `month year`
+   * `12.8` seconds of the "gradient black" title
+     * Main: `name of the speaker`
+     * Subtitle: `title of talk`
+       * If the talk has a _very_ long title, you might need to do something special
+   Yes, This means the text layers goes the main talk video, usually this is fine.
+
 
 Line this up so that the logo, jingle, and 6 second title are at the start of the timeline, and the 12 second title comes immediately after the 6 second one.  If you get this right, the jingle and titles should last longer than the logo, but they should end at the exact same time.  The logo should disappear just as the jingle does it's final flourish and starts to taper off.
 
+In iMovie, if you line everything up correctly, it will look _something_ like this:
+
+![iMovie example intro timeline](https://assets.lrug.org/readme/video-editing-example-intro.png){: width="100%"}
+
 ## Main content
 
- 1. Drop the main video of the meeting in here so the title and jingle overlap by about 6s.
- 2. Trim the main video to the start of the speakers talk, which might not be when they start to speak, use your judgement.  So far I've chosen not to include intro or applause.
- 3. Trim the main video to stop at what feels like the end of the speakers talk, usually just before the applause or host saying "thanks"
- 4. Improve the audio:
-    1. Boost volume: on the main content drag the line on the audio waveform up to the top of the blue waveform section to boost the audio to 400%
-    2. Auto levels: select the main content clip and press the volume icon in the preview window then press the "Auto" button to average out the levels (helps with a quiet speaker)
- 5. Check for anything you need to cut - technical hitches, interlopers annotating the screen, unexpected pet or family interruptions, etc...  It might be useful to introduce a freeze-frame and stretch it to cover problems in the video if the audio is still usable.  You can split the audio from the main content if needs be to achieve this.
+ 1. **Drop the main video of the meeting in** here so the title and jingle overlap by about 6s.
+ 2. **Trim the main video to the start** of the speakers talk, which might not be when they start to speak, use your judgement.  So far I've chosen not to include intro or applause.
+ 3. **Trim the main video to stop** at what feels like the end of the speakers talk, usually just before the applause or host saying "thanks"
+ 4. **Improve the audio**:
+    1. **Boost volume**:
+
+       Either:
+
+       On the main content drag the line on the audio waveform up to the top of the blue waveform section to boost the audio to at least 200%, if not all the way up to 400%.
+
+       or:
+
+       Select the main content clip and press the `volume` icon in the preview window then drag the slider next to the `Auto` and `speaker` icons to at least 200%, if not all the way up to 400%.
+
+    2. **Auto levels**: select the main content clip and press the `volume` icon in the preview window then press the `Auto` button to average out the levels (helps with a quiet speaker)
+    3. **Reduce background noise**: select the main content clip and press the `noise reduction and equalizer` icon in the preview window, then check the `Reduce background noise` checkbox and set the slider to at least 50%.
+    4. **Equalizer**: select the main content clip and press the `noise reduction and equalizer` icon in the preview window, then choose "Voice enhance" from the `Equalizer` drop down.
+    Listen to some of the audio - if it sounds weird, fiddle with the volume boost to avoid clipping and see what works.
+ 5. **Check for anything you need to cut** - technical hitches, interlopers annotating the screen, unexpected pet or family interruptions, etc...  It might be useful to introduce a freeze-frame and stretch it to cover problems in the video if the audio is still usable.  You can split the audio from the main content if needs be to achieve this.
 
 ## Outro
 
- * 13 seconds of the LRUG logo
- * `19.1` seconds of the "44th street medium" jingle - positioning this is annoying, as you have to position the start, not the end.  If "snapping" is on, put the playhead right at the end of the logo and slide the jingle audio along until the playhead flashes to indicate it's snapped.  We don't want the audio lasting longer than the logo.
- * `13.0` seconds of the "gradient black" title
-   * Main: "LRUG - `month year`"
-   * Subtitle: thanks to a sponsor or blank
+* Video Track
+  * 13 seconds of the LRUG logo - starting immediately after the end of the main talk video
+* Audio track
+  * `19.1` seconds of the "44th street medium" jingle - to start ~6.1s _before_ the end of the main talk audio.
+
+    Positioning this is annoying, as you have to position the start, not the end.  If "snapping" is on, put the playhead right at the end of the logo and slide the jingle audio along until the playhead flashes to indicate it's snapped.  We don't want the audio lasting longer than the logo.
+* Text track
+  * `13.0` seconds of the "gradient black" title - starting immediately after the end of the main talk video - to overlay entirely on top of the logo
+    * Main: "LRUG - `month year`"
+    * Subtitle: thanks to a sponsor or blank
 
 We want to fade up the jingle and fade down the main content so that the jingle, which starts very loud, won't drown out the last few words.  Equally though, we don't want the last few seconds of the main content video to be as abrupt as all that.  Sometimes you have to finesse the fade down and the trim point.
 
  1. Fade up the jingle by pulling the audio line right from the start - usually fade up for the full 6 seconds of overlap
  2. Fade down the main content by pulling the audio line left from the end - usually fade down for about 5 seconds of the overlap
+
+
+In iMovie, if you line everything up correctly, it will look _something_ like this:
+
+![iMovie example outro timeline](https://assets.lrug.org/readme/video-editing-example-outro.png){: width="100%"}
 
 ## Export
 
@@ -75,7 +110,7 @@ Note: the resolution, quality, and compress options in the iMovie share UI are h
 The expected sizes of the output are always way out.  A 25 minute talk usually comes out about 250Mb or so, but it'll estimate at ~700Mb.  If that's not the case then we will have to compress it further with `ffmpeg`.
 
  1. Install `ffmpeg` via `brew` - the default homebrew version of `ffmpeg` installs all possible codecs and dependencies so this might take a while, but it does mean it's fully featured and can do everything
- 2. Compress the output from iMovie further `ffmpeg -i input.mp4 -b:v 750k output.mp4` - the `-b 750k` part tells it to restrict data to ~750kbps.  This should give you a further 50% reduction thereabouts from the imovie export
+ 2. Compress the output from iMovie further `ffmpeg -i input.mp4 -b:v 750k output.mp4` - the `-b 750k` part tells it to restrict data to ~750kbps.  This should give you a further 50% reduction thereabouts from the iMovie export
 
  If the video is still more than say 300Mb you'll want to explore further options to tradeoff quality for size.
 
@@ -84,6 +119,7 @@ The expected sizes of the output are always way out.  A 25 minute talk usually c
  1. Rename file to `speaker-name-title-lrug-mmm-yyyy.mp4` - all lower case, remove extra punctuation, etc..  Note: unlike the rest of this guide, we use `mmm` here and want the 3-letter abbreviation of the month, else where in this guide we use `mmmm` and want the full month name.
  2. `scp` to lrug.org: `sites/lrug.org/assets/videos/yyyy/mmmm/`
  3. Add to relevant `yyyy.yml` in `data/coverage` in [the lrug.org repo](https://github.com/lrug/lrug.org) as:
+
     ```yaml
     mmmm:
       title-parameterised:
@@ -92,6 +128,7 @@ The expected sizes of the output are always way out.  A 25 minute talk usually c
         title: 'LRUG mmmm yyyy - speaker name - talk title'
     ```
  4. Add coverage tag to relevant meeting page [the lrug.org repo](https://github.com/lrug/lrug.org):
-    ```
+
+    ```ruby
     {::coverage year="yyyy" month="mmmm" talk="title-parameterised" /}
     ```


### PR DESCRIPTION
1. Add some tweaks to the video-editing notes
2. Remove twitter references from the attendee readme in favour of mastodon
3. Remove Skills Matter references from the attendee readme and add details about venue sponsorhip
4. Clarify that subject matter for LRUG talks is broad, and explicitly doesn't _have_ to be about ruby

Worth checking these changes in the individual commits.

Note - requires a tiny change to lrug.org as PR'd here: lrug/lrug.org/pull/311